### PR TITLE
Added space on app name

### DIFF
--- a/net.wz2100.wz2100.appdata.xml
+++ b/net.wz2100.wz2100.appdata.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="desktop">
   <id>net.wz2100.wz2100</id>
-  <name>Warzone2100</name>
+  <name>Warzone 2100</name>
   <launchable type="desktop-id">net.wz2100.wz2100.desktop</launchable>
   <metadata_license>CC0-1.0</metadata_license>
   <summary>In Warzone 2100, you command the forces of The Project in a battle to rebuild the world after mankind has almost been destroyed by nuclear missiles.</summary>


### PR DESCRIPTION
Fixed app name, which is composed of two words [Warzone 2100] instead of just [Warzone2100].

![image](https://user-images.githubusercontent.com/43529725/90714345-50483700-e25c-11ea-88e9-5f83eb4f33d6.png)
![image](https://user-images.githubusercontent.com/43529725/90714413-740b7d00-e25c-11ea-949c-6840d223c50f.png)
